### PR TITLE
feat: elevent labs tts (requires API key)

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -2,6 +2,7 @@ import * as matchers from '@testing-library/jest-dom/matchers';
 import { cleanup } from '@testing-library/react';
 import { afterEach, beforeEach, expect, vi } from 'vitest';
 
+import { resetSpeechServiceForTests } from '../utils/speech-service';
 import { resetWordSetCache } from '../utils/word-sets';
 
 // Extend Vitest's expect with jest-dom matchers
@@ -10,10 +11,12 @@ expect.extend(matchers);
 // Cleanup after each test
 afterEach(() => {
   cleanup();
+  resetSpeechServiceForTests();
 });
 
 beforeEach(() => {
   resetWordSetCache();
+  resetSpeechServiceForTests();
   vi.stubGlobal(
     'fetch',
     vi.fn(async (input: string | URL | Request) => {
@@ -51,5 +54,17 @@ if (!global.ResizeObserver) {
       unobserve() {}
       disconnect() {}
     },
+  });
+}
+
+if (!global.URL.createObjectURL) {
+  Object.defineProperty(global.URL, 'createObjectURL', {
+    value: vi.fn(() => 'blob:mock-audio'),
+  });
+}
+
+if (!global.URL.revokeObjectURL) {
+  Object.defineProperty(global.URL, 'revokeObjectURL', {
+    value: vi.fn(),
   });
 }

--- a/src/__tests__/speech-service.test.tsx
+++ b/src/__tests__/speech-service.test.tsx
@@ -122,6 +122,42 @@ describe('speech service', () => {
     expect(requestInit.body).not.toContain('"next_text"');
   });
 
+  it('uses the per-language mapped voice when no explicit voice id is configured', async () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
+    initializeSpeech();
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(new Blob(['audio'], { type: 'audio/mpeg' }), { status: 200 }),
+    );
+
+    speak('friend', LANGUAGES[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [requestUrl] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain('/JBFqnCBsd6RMkjVDRZzb');
+  });
+
+  it('prefers an explicitly configured voice id over the per-language mapping', async () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+    initializeSpeech();
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(new Blob(['audio'], { type: 'audio/mpeg' }), { status: 200 }),
+    );
+
+    speak('friend', LANGUAGES[0]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [requestUrl] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain('/voice-123');
+  });
+
   it('queues only the newest request while browser speech is in progress', async () => {
     speak('first', LANGUAGES[0]);
     speak('second', LANGUAGES[0]);

--- a/src/__tests__/speech-service.test.tsx
+++ b/src/__tests__/speech-service.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AppShell } from '../components/app-shell';
+import { LANGUAGES } from '../utils/languages';
+import { getSpeechStatusForTests, initializeSpeech, speak } from '../utils/speech-service';
+
+const mockSpeechSynthesisSpeak = vi.fn();
+const mockSpeechSynthesisCancel = vi.fn();
+
+type MockUtterance = {
+  lang: string;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+  pitch: number;
+  rate: number;
+  text: string;
+};
+
+class MockAudio {
+  static instances: MockAudio[] = [];
+
+  onended: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  pause = vi.fn();
+  play = vi.fn(async () => undefined);
+
+  constructor(public src: string) {
+    MockAudio.instances.push(this);
+  }
+
+  end() {
+    this.onended?.();
+  }
+}
+
+describe('speech service', () => {
+  beforeEach(() => {
+    MockAudio.instances = [];
+    mockSpeechSynthesisSpeak.mockClear();
+    mockSpeechSynthesisCancel.mockClear();
+    vi.mocked(URL.createObjectURL).mockImplementation(
+      () => `blob:audio-${MockAudio.instances.length}`,
+    );
+
+    global.Audio = MockAudio as unknown as typeof Audio;
+    global.speechSynthesis = {
+      speak: mockSpeechSynthesisSpeak,
+      cancel: mockSpeechSynthesisCancel,
+      pause: vi.fn(),
+      resume: vi.fn(),
+      getVoices: vi.fn(() => []),
+    } as unknown as SpeechSynthesis;
+
+    global.SpeechSynthesisUtterance = vi.fn().mockImplementation((text) => {
+      const utterance: MockUtterance = {
+        text,
+        lang: '',
+        rate: 1,
+        pitch: 1,
+        onend: null,
+        onerror: null,
+      };
+      return utterance;
+    });
+
+    window.history.pushState({}, '', '/');
+  });
+
+  it('reads the hidden ElevenLabs params once and removes them from the URL', () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+
+    initializeSpeech();
+
+    expect(window.location.search).toBe('');
+    expect(getSpeechStatusForTests().isElevenLabsActive).toBe(true);
+  });
+
+  it('reuses cached ElevenLabs audio for the same locale and text', async () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+    initializeSpeech();
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(new Blob(['audio'], { type: 'audio/mpeg' }), { status: 200 }),
+    );
+
+    speak('kot', LANGUAGES[7]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(MockAudio.instances).toHaveLength(1);
+    });
+
+    MockAudio.instances[0].end();
+    speak('kot', LANGUAGES[7]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+      expect(MockAudio.instances).toHaveLength(2);
+    });
+  });
+
+  it('uses the mapped Polish voice and forces the Polish language code', async () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
+    initializeSpeech();
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(new Blob(['audio'], { type: 'audio/mpeg' }), { status: 200 }),
+    );
+
+    speak('hamak', LANGUAGES[7]);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+
+    const [requestUrl, requestInit] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
+    expect(requestUrl).toContain('/TX3LPaxmHKxFdv7VOQHJ');
+    expect(requestInit.body).toContain('"language_code":"pl"');
+    expect(requestInit.body).toContain('"model_id":"eleven_multilingual_v2"');
+    expect(requestInit.body).toContain('"previous_text":"Następne słowo jest po polsku."');
+    expect(requestInit.body).not.toContain('"next_text"');
+  });
+
+  it('queues only the newest request while browser speech is in progress', async () => {
+    speak('first', LANGUAGES[0]);
+    speak('second', LANGUAGES[0]);
+    speak('third', LANGUAGES[0]);
+
+    expect(mockSpeechSynthesisSpeak).toHaveBeenCalledTimes(1);
+    const firstUtterance = vi.mocked(SpeechSynthesisUtterance).mock.results[0]
+      .value as MockUtterance;
+    firstUtterance.onend?.();
+
+    await waitFor(() => {
+      expect(mockSpeechSynthesisSpeak).toHaveBeenCalledTimes(2);
+    });
+
+    const secondUtterance = vi.mocked(SpeechSynthesisUtterance).mock.results[1]
+      .value as MockUtterance;
+    expect(secondUtterance.text).toBe('third');
+  });
+
+  it('disables ElevenLabs after a hard failure and falls back to browser speech', async () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+    initializeSpeech();
+
+    vi.mocked(fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+    speak('kot', LANGUAGES[7]);
+
+    await waitFor(() => {
+      expect(mockSpeechSynthesisSpeak).toHaveBeenCalledTimes(1);
+    });
+
+    expect(getSpeechStatusForTests().isElevenLabsActive).toBe(false);
+
+    const firstUtterance = vi.mocked(SpeechSynthesisUtterance).mock.results[0]
+      .value as MockUtterance;
+    firstUtterance.onend?.();
+
+    speak('pies', LANGUAGES[7]);
+
+    await waitFor(() => {
+      expect(mockSpeechSynthesisSpeak).toHaveBeenCalledTimes(2);
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('shows the active badge only when ElevenLabs is enabled for new requests', () => {
+    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
+    initializeSpeech();
+
+    render(
+      <AppShell>
+        <div>child</div>
+      </AppShell>,
+    );
+
+    expect(screen.getByText('ElevenLabs TTS')).toBeInTheDocument();
+  });
+});

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 import { cn } from '../lib/utils';
+import { useSpeechStatus } from '../utils/speech-service';
 import { Toggle } from './ui/toggle';
 
 type AppShellProps = {
@@ -12,6 +13,7 @@ type AppShellProps = {
 
 export function AppShell({ children, className }: AppShellProps) {
   const [isDark, setIsDark] = useState(false);
+  const { isElevenLabsActive } = useSpeechStatus();
 
   useEffect(() => {
     const storedTheme = window.localStorage.getItem('memo-bot-theme');
@@ -41,7 +43,8 @@ export function AppShell({ children, className }: AppShellProps) {
           className,
         )}
       >
-        <div className="fixed right-4 top-4 z-30 flex justify-end sm:right-6 lg:right-10">
+        <div className="fixed right-4 top-4 z-30 flex items-center justify-end gap-2 sm:right-6 lg:right-10">
+          {isElevenLabsActive && <div className="eyebrow">ElevenLabs TTS</div>}
           <Toggle
             pressed={isDark}
             onPressedChange={handleThemeChange}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './app';
+import { initializeSpeech } from './utils/speech-service';
+
+initializeSpeech();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/utils/speak.ts
+++ b/src/utils/speak.ts
@@ -1,9 +1,1 @@
-import type { Language } from './languages';
-
-export function speak(text: string, language: Language) {
-  const utterance = new SpeechSynthesisUtterance(text);
-  utterance.lang = language.code;
-  utterance.rate = 0.6; // Slightly slower for children
-  utterance.pitch = 1;
-  window.speechSynthesis.speak(utterance);
-}
+export { speak } from './speech-service';

--- a/src/utils/speech-service.ts
+++ b/src/utils/speech-service.ts
@@ -62,7 +62,7 @@ const speechCache = new Map<string, SpeechCacheEntry>();
 
 let hasInitialized = false;
 let elevenLabsApiKey: string | null = null;
-let configuredVoiceId = DEFAULT_ELEVENLABS_VOICE_ID;
+let configuredVoiceId: string | null = null;
 let isElevenLabsDisabled = false;
 let currentPlaybackToken: number | null = null;
 let currentAudio: HTMLAudioElement | null = null;
@@ -305,7 +305,7 @@ export function initializeSpeech() {
   const hadHiddenParam = removedApiKey || removedVoiceId;
 
   elevenLabsApiKey = apiKey || null;
-  configuredVoiceId = voiceId || DEFAULT_ELEVENLABS_VOICE_ID;
+  configuredVoiceId = voiceId || null;
   isElevenLabsDisabled = false;
   speechStatus = {
     isElevenLabsActive: false,
@@ -345,7 +345,7 @@ export function resetSpeechServiceForTests() {
   nextPlaybackToken = 0;
   hasInitialized = false;
   elevenLabsApiKey = null;
-  configuredVoiceId = DEFAULT_ELEVENLABS_VOICE_ID;
+  configuredVoiceId = null;
   isElevenLabsDisabled = false;
   speechStatus = {
     isElevenLabsActive: false,

--- a/src/utils/speech-service.ts
+++ b/src/utils/speech-service.ts
@@ -1,0 +1,365 @@
+import { useSyncExternalStore } from 'react';
+
+import type { Language } from './languages';
+
+const ELEVENLABS_API_KEY_PARAM = 'elevenlabs-api-key';
+const ELEVENLABS_VOICE_ID_PARAM = 'elevenlabs-voice-id';
+const ELEVENLABS_MODEL_ID = 'eleven_multilingual_v2';
+const ELEVENLABS_TTS_URL = 'https://api.elevenlabs.io/v1/text-to-speech';
+const DEFAULT_ELEVENLABS_VOICE_ID = 'TX3LPaxmHKxFdv7VOQHJ';
+const ELEVENLABS_VOICE_IDS_BY_LANGUAGE: Record<string, string> = {
+  'de-DE': 'TX3LPaxmHKxFdv7VOQHJ',
+  'en-GB': 'JBFqnCBsd6RMkjVDRZzb',
+  'en-US': 'TX3LPaxmHKxFdv7VOQHJ',
+  'es-ES': 'JBFqnCBsd6RMkjVDRZzb',
+  'fr-FR': 'JBFqnCBsd6RMkjVDRZzb',
+  'it-IT': 'SAz9YHcvj6GT2YYXdXww',
+  'pl-PL': 'TX3LPaxmHKxFdv7VOQHJ',
+  'pt-PT': 'SAz9YHcvj6GT2YYXdXww',
+};
+const ELEVENLABS_CONTEXT_BY_LANGUAGE: Record<string, { previousText: string }> = {
+  'de-DE': {
+    previousText: 'Das nächste Wort ist auf Deutsch.',
+  },
+  'en-GB': {
+    previousText: 'The next word is in British English.',
+  },
+  'en-US': {
+    previousText: 'The next word is in American English.',
+  },
+  'es-ES': {
+    previousText: 'La siguiente palabra está en español.',
+  },
+  'fr-FR': {
+    previousText: 'Le mot suivant est en français.',
+  },
+  'it-IT': {
+    previousText: 'La prossima parola è in italiano.',
+  },
+  'pl-PL': {
+    previousText: 'Następne słowo jest po polsku.',
+  },
+  'pt-PT': {
+    previousText: 'A próxima palavra está em português.',
+  },
+};
+
+type SpeechRequest = {
+  language: Language;
+  text: string;
+};
+
+type SpeechStatus = {
+  isElevenLabsActive: boolean;
+};
+
+type SpeechCacheEntry = {
+  objectUrl: string;
+};
+
+const listeners = new Set<() => void>();
+const speechCache = new Map<string, SpeechCacheEntry>();
+
+let hasInitialized = false;
+let elevenLabsApiKey: string | null = null;
+let configuredVoiceId = DEFAULT_ELEVENLABS_VOICE_ID;
+let isElevenLabsDisabled = false;
+let currentPlaybackToken: number | null = null;
+let currentAudio: HTMLAudioElement | null = null;
+let queuedRequest: SpeechRequest | null = null;
+let nextPlaybackToken = 0;
+let speechStatus: SpeechStatus = {
+  isElevenLabsActive: false,
+};
+
+function emitStatusChange() {
+  speechStatus = {
+    isElevenLabsActive: elevenLabsApiKey != null && !isElevenLabsDisabled,
+  };
+  listeners.forEach((listener) => listener());
+}
+
+function getSpeechStatus(): SpeechStatus {
+  return speechStatus;
+}
+
+function subscribeToSpeechStatus(listener: () => void) {
+  listeners.add(listener);
+
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getCacheKey({ language, text }: SpeechRequest) {
+  return `${language.code}::${text}`;
+}
+
+function getUrlWithoutHiddenParams(url: URL) {
+  const nextSearch = url.searchParams.toString();
+  return `${url.pathname}${nextSearch ? `?${nextSearch}` : ''}${url.hash}`;
+}
+
+function canRequestElevenLabs() {
+  return elevenLabsApiKey != null && !isElevenLabsDisabled;
+}
+
+function finishPlayback(playbackToken: number) {
+  if (currentPlaybackToken !== playbackToken) {
+    return;
+  }
+
+  currentPlaybackToken = null;
+  currentAudio = null;
+
+  if (queuedRequest == null) {
+    return;
+  }
+
+  const nextRequest = queuedRequest;
+  queuedRequest = null;
+  void playSpeechRequest(nextRequest);
+}
+
+function playObjectUrl(objectUrl: string, playbackToken: number) {
+  const audio = new Audio(objectUrl);
+  currentAudio = audio;
+  audio.onended = () => {
+    finishPlayback(playbackToken);
+  };
+  audio.onerror = () => {
+    finishPlayback(playbackToken);
+  };
+
+  const playResult = audio.play();
+  if (playResult != null && typeof playResult.catch === 'function') {
+    void playResult.catch(() => {
+      finishPlayback(playbackToken);
+    });
+  }
+}
+
+function playWithBrowserSpeech({ language, text }: SpeechRequest, playbackToken: number) {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.speechSynthesis === 'undefined' ||
+    typeof SpeechSynthesisUtterance === 'undefined'
+  ) {
+    finishPlayback(playbackToken);
+    return;
+  }
+
+  try {
+    const utterance = new SpeechSynthesisUtterance(text);
+    utterance.lang = language.code;
+    utterance.rate = 0.6;
+    utterance.pitch = 1;
+    utterance.onend = () => {
+      finishPlayback(playbackToken);
+    };
+    utterance.onerror = () => {
+      finishPlayback(playbackToken);
+    };
+    window.speechSynthesis.speak(utterance);
+  } catch {
+    finishPlayback(playbackToken);
+  }
+}
+
+function disableElevenLabs() {
+  if (isElevenLabsDisabled) {
+    return;
+  }
+
+  isElevenLabsDisabled = true;
+  emitStatusChange();
+}
+
+async function readErrorText(response: Response) {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+async function shouldDisableElevenLabs(response: Response) {
+  if (response.status === 401 || response.status === 403) {
+    return true;
+  }
+
+  const errorText = await readErrorText(response);
+  return /\b(quota|credit|credits|billing|payment required|insufficient)\b/i.test(errorText);
+}
+
+function getElevenLabsLanguageCode(language: Language) {
+  return language.code.split('-')[0].toLowerCase();
+}
+
+function getElevenLabsVoiceId(language: Language) {
+  return (
+    configuredVoiceId ??
+    ELEVENLABS_VOICE_IDS_BY_LANGUAGE[language.code] ??
+    DEFAULT_ELEVENLABS_VOICE_ID
+  );
+}
+
+function getElevenLabsContext(language: Language) {
+  return (
+    ELEVENLABS_CONTEXT_BY_LANGUAGE[language.code] ?? {
+      previousText: '',
+    }
+  );
+}
+
+async function synthesizeWithElevenLabs(request: SpeechRequest) {
+  const cachedAudio = speechCache.get(getCacheKey(request));
+  if (cachedAudio != null) {
+    return cachedAudio.objectUrl;
+  }
+
+  if (!canRequestElevenLabs()) {
+    return null;
+  }
+
+  const voiceId = getElevenLabsVoiceId(request.language);
+  const context = getElevenLabsContext(request.language);
+  if (voiceId == null) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${ELEVENLABS_TTS_URL}/${voiceId}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'audio/mpeg',
+        'xi-api-key': elevenLabsApiKey!,
+      },
+      body: JSON.stringify({
+        text: request.text,
+        model_id: ELEVENLABS_MODEL_ID,
+        language_code: getElevenLabsLanguageCode(request.language),
+        previous_text: context.previousText,
+      }),
+    });
+
+    if (!response.ok) {
+      if (await shouldDisableElevenLabs(response)) {
+        disableElevenLabs();
+      }
+      return null;
+    }
+
+    const audioBlob = await response.blob();
+    const objectUrl = URL.createObjectURL(audioBlob);
+    speechCache.set(getCacheKey(request), { objectUrl });
+    return objectUrl;
+  } catch {
+    return null;
+  }
+}
+
+async function playSpeechRequest(request: SpeechRequest) {
+  const playbackToken = ++nextPlaybackToken;
+  currentPlaybackToken = playbackToken;
+
+  const cachedAudio = speechCache.get(getCacheKey(request));
+  if (cachedAudio != null) {
+    playObjectUrl(cachedAudio.objectUrl, playbackToken);
+    return;
+  }
+
+  if (!canRequestElevenLabs()) {
+    playWithBrowserSpeech(request, playbackToken);
+    return;
+  }
+
+  const elevenLabsAudio = await synthesizeWithElevenLabs(request);
+  if (currentPlaybackToken !== playbackToken) {
+    return;
+  }
+
+  if (elevenLabsAudio != null) {
+    playObjectUrl(elevenLabsAudio, playbackToken);
+    return;
+  }
+
+  playWithBrowserSpeech(request, playbackToken);
+}
+
+export function initializeSpeech() {
+  if (hasInitialized || typeof window === 'undefined') {
+    return;
+  }
+
+  hasInitialized = true;
+
+  const url = new URL(window.location.href);
+  const apiKey = url.searchParams.get(ELEVENLABS_API_KEY_PARAM)?.trim();
+  const voiceId = url.searchParams.get(ELEVENLABS_VOICE_ID_PARAM)?.trim();
+  const removedApiKey = url.searchParams.has(ELEVENLABS_API_KEY_PARAM);
+  const removedVoiceId = url.searchParams.has(ELEVENLABS_VOICE_ID_PARAM);
+  url.searchParams.delete(ELEVENLABS_API_KEY_PARAM);
+  url.searchParams.delete(ELEVENLABS_VOICE_ID_PARAM);
+  const hadHiddenParam = removedApiKey || removedVoiceId;
+
+  elevenLabsApiKey = apiKey || null;
+  configuredVoiceId = voiceId || DEFAULT_ELEVENLABS_VOICE_ID;
+  isElevenLabsDisabled = false;
+  speechStatus = {
+    isElevenLabsActive: false,
+  };
+
+  if (hadHiddenParam) {
+    window.history.replaceState(window.history.state, '', getUrlWithoutHiddenParams(url));
+  }
+
+  emitStatusChange();
+}
+
+export function speak(text: string, language: Language) {
+  if (!text.trim()) {
+    return;
+  }
+
+  const nextRequest = { language, text };
+
+  if (currentPlaybackToken != null) {
+    queuedRequest = nextRequest;
+    return;
+  }
+
+  void playSpeechRequest(nextRequest);
+}
+
+export function useSpeechStatus() {
+  return useSyncExternalStore(subscribeToSpeechStatus, getSpeechStatus, getSpeechStatus);
+}
+
+export function resetSpeechServiceForTests() {
+  currentAudio?.pause?.();
+  currentAudio = null;
+  currentPlaybackToken = null;
+  queuedRequest = null;
+  nextPlaybackToken = 0;
+  hasInitialized = false;
+  elevenLabsApiKey = null;
+  configuredVoiceId = DEFAULT_ELEVENLABS_VOICE_ID;
+  isElevenLabsDisabled = false;
+  speechStatus = {
+    isElevenLabsActive: false,
+  };
+
+  for (const entry of speechCache.values()) {
+    URL.revokeObjectURL?.(entry.objectUrl);
+  }
+
+  speechCache.clear();
+  window.speechSynthesis?.cancel?.();
+  emitStatusChange();
+}
+
+export function getSpeechStatusForTests() {
+  return getSpeechStatus();
+}


### PR DESCRIPTION
## What does this PR do?

Adds a hidden ElevenLabs-backed TTS path that can be enabled from URL params for private use, while keeping browser speech as the default and fallback path. It also fixes voice selection so per-language defaults are used unless an explicit `elevenlabs-voice-id` override is provided.

## Relevant implementation details

- Added a dedicated speech service that reads `elevenlabs-api-key` once at startup, optionally accepts `elevenlabs-voice-id`, and immediately removes both params from the visible URL.
- Keeps the ElevenLabs key only in memory for the current tab and never stores it in app state or local storage.
- Uses the configured voice override only when present; otherwise falls back to the language-specific voice map before the global default voice.
- Uses a single playback coordinator for ElevenLabs audio and browser TTS with one global queued item, where newer requests replace older queued ones.
- Caches generated ElevenLabs audio in memory for the lifetime of the tab by exact `language + text`, so repeated prompts do not consume more quota.
- Falls back to browser TTS on transient failures and disables ElevenLabs for the rest of the tab after hard auth/quota-style failures.
- Shows a small `ElevenLabs TTS` badge near the theme toggle only while ElevenLabs is active for new uncached requests.
- Added focused tests for hidden-param scrubbing, queue behavior, cache reuse, voice selection precedence, hard-failure fallback, and badge visibility.

## How did you test this?

- `bun run validate`
