### PR TITLE
feat: session timer

### DIFF
--- a/public/word-sets/pl/100-popularnych-trudnych-slow.txt
+++ b/public/word-sets/pl/100-popularnych-trudnych-slow.txt
@@ -70,7 +70,7 @@ podróż
 podwórko
 porządek
 pracuję
-próbuje
+próbuję
 przedszkole
 przyroda
 ręka

--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import App from '../app';
 import { useGameState } from '../stores/game-store';
@@ -39,6 +39,10 @@ describe('App', () => {
     useGameState.getState().resetGame();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('displays InputScreen when game status is initial', () => {
     // Game starts in initial state (no words)
     render(<App />);
@@ -60,6 +64,45 @@ describe('App', () => {
     // Should show QuestionScreen
     expect(screen.getByText(/Type what you hear!/i)).toBeInTheDocument();
     expect(screen.getByPlaceholderText(/Type here/i)).toBeInTheDocument();
+  });
+
+  it('auto-pauses after inactivity and when the tab becomes hidden', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-11T12:00:00Z'));
+
+    useGameState
+      .getState()
+      .startGame([{ word: 'hello', prompt: undefined }], LANGUAGES[0], 'relaxed', 'manual');
+
+    render(<App />);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    let session = useGameState.getState().session;
+    expect(session.isPaused).toBe(true);
+    expect(session.accumulatedActiveMs).toBe(30_000);
+
+    useGameState.getState().recordSessionActivity();
+
+    session = useGameState.getState().session;
+    expect(session.isPaused).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    session = useGameState.getState().session;
+    expect(session.isPaused).toBe(true);
+    expect(session.accumulatedActiveMs).toBe(35_000);
+
+    Object.defineProperty(document, 'hidden', {
+      configurable: true,
+      value: false,
+    });
   });
 
   it('displays ResultsScreen when game status is finished', () => {

--- a/src/__tests__/game-logic.test.ts
+++ b/src/__tests__/game-logic.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useGameState } from '../stores/game-store';
 import type { Word } from '../types';
@@ -16,6 +16,10 @@ if (!global.crypto) {
 describe('Game Store Logic', () => {
   beforeEach(() => {
     useGameState.getState().resetGame();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should handle duplicate words correctly by ID', () => {
@@ -116,5 +120,48 @@ describe('Game Store Logic', () => {
     expect(afterSecondCorrect.completedWords[0].id).toBe(challengeWord.id);
     expect(afterSecondCorrect.completedWords[0].correctStreak).toBe(2);
     expect(afterSecondCorrect.completedWords[0].incorrectCount).toBe(1);
+  });
+
+  it('starts a running session when the game starts', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-11T10:00:00Z'));
+
+    useGameState.getState().startGame([{ word: 'hello' }], LANGUAGES[0], 'relaxed', 'manual');
+
+    const { session } = useGameState.getState();
+    expect(session.startedAt).toBe(Date.now());
+    expect(session.endedAt).toBeNull();
+    expect(session.accumulatedActiveMs).toBe(0);
+    expect(session.activeSince).toBe(Date.now());
+    expect(session.lastActivityAt).toBe(Date.now());
+    expect(session.isPaused).toBe(false);
+  });
+
+  it('tracks active session time across pause, resume, and finish', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-11T10:00:00Z'));
+
+    useGameState.getState().startGame([{ word: 'hello' }], LANGUAGES[0], 'relaxed', 'manual');
+
+    vi.advanceTimersByTime(10_000);
+    useGameState.getState().pauseSession();
+
+    let session = useGameState.getState().session;
+    expect(session.accumulatedActiveMs).toBe(10_000);
+    expect(session.isPaused).toBe(true);
+    expect(session.activeSince).toBeNull();
+
+    vi.advanceTimersByTime(60_000);
+    useGameState.getState().resumeSession();
+
+    vi.advanceTimersByTime(5_000);
+    const currentWord = useGameState.getState().pendingWords[0];
+    useGameState.getState().correctAnswer(currentWord);
+
+    session = useGameState.getState().session;
+    expect(session.accumulatedActiveMs).toBe(15_000);
+    expect(session.isPaused).toBe(true);
+    expect(session.activeSince).toBeNull();
+    expect(session.endedAt).toBe(Date.now());
   });
 });

--- a/src/__tests__/results-screen.test.tsx
+++ b/src/__tests__/results-screen.test.tsx
@@ -187,4 +187,35 @@ describe('ResultsScreen', () => {
     // Check that the status label exists
     expect(screen.getByText(/skipped/i, { selector: 'span.text-yellow-400' })).toBeInTheDocument();
   });
+
+  it('shows session duration when timing data is available', () => {
+    const endedAt = new Date('2026-04-11T14:37:00Z').getTime();
+
+    useGameState.setState({
+      completedWords: [
+        {
+          id: '1',
+          word: 'hello',
+          prompt: undefined,
+          correctStreak: 2,
+          incorrectCount: 0,
+          skipped: false,
+        },
+      ],
+      session: {
+        startedAt: endedAt - 134_000,
+        endedAt,
+        accumulatedActiveMs: 134_000,
+        activeSince: null,
+        lastActivityAt: endedAt - 5_000,
+        isPaused: true,
+      },
+    });
+
+    render(<ResultsScreen />);
+
+    expect(screen.getByText(/Time spent/i)).toBeInTheDocument();
+    expect(screen.getByText('2m 14s')).toBeInTheDocument();
+    expect(screen.queryByText(/Ended at/i)).not.toBeInTheDocument();
+  });
 });

--- a/src/__tests__/speech-service.test.tsx
+++ b/src/__tests__/speech-service.test.tsx
@@ -119,7 +119,7 @@ describe('speech service', () => {
     expect(requestInit.body).toContain('"language_code":"pl"');
     expect(requestInit.body).toContain('"model_id":"eleven_multilingual_v2"');
     expect(requestInit.body).toContain('"previous_text":"Następne słowo jest po polsku."');
-    expect(requestInit.body).not.toContain('"next_text"');
+    expect(requestInit.body).toContain('"next_text":"."');
   });
 
   it('uses the per-language mapped voice when no explicit voice id is configured', async () => {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,10 +1,16 @@
 import { Footer } from './components/footer';
 import { Toaster } from './components/ui/toaster';
 import { useBeforeUnload } from './hooks/use-before-unload';
+import { useLearningSession } from './hooks/use-learning-session';
 import InputScreen from './screens/input-screen';
 import QuestionScreen from './screens/question-screen';
 import ResultsScreen from './screens/results-screen';
 import { useCurrentWord, useGameStatus } from './stores/selectors';
+
+function LearningSessionController() {
+  useLearningSession();
+  return null;
+}
 
 export default function App() {
   const status = useGameStatus();
@@ -39,6 +45,7 @@ export default function App() {
 
   return (
     <>
+      <LearningSessionController />
       <QuestionScreen
         key={`${currentWord.word}-${currentWord.correctStreak}-${currentWord.incorrectCount}`}
       />

--- a/src/hooks/use-learning-session.ts
+++ b/src/hooks/use-learning-session.ts
@@ -1,0 +1,47 @@
+import { useEffect } from 'react';
+
+import { useGameState } from '../stores/game-store';
+
+export const SESSION_IDLE_TIMEOUT_MS = 30_000;
+
+export function useLearningSession() {
+  const { startedAt, endedAt, isPaused, lastActivityAt } = useGameState((state) => state.session);
+  const pauseSession = useGameState((state) => state.pauseSession);
+
+  useEffect(() => {
+    if (startedAt == null || endedAt != null || isPaused || lastActivityAt == null) {
+      return;
+    }
+
+    const remainingMs = SESSION_IDLE_TIMEOUT_MS - (Date.now() - lastActivityAt);
+    if (remainingMs <= 0) {
+      pauseSession();
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      pauseSession();
+    }, remainingMs);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [startedAt, endedAt, isPaused, lastActivityAt, pauseSession]);
+
+  useEffect(() => {
+    if (startedAt == null || endedAt != null) {
+      return;
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        pauseSession();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [startedAt, endedAt, pauseSession]);
+}

--- a/src/screens/question-screen.tsx
+++ b/src/screens/question-screen.tsx
@@ -26,6 +26,7 @@ export default function QuestionScreen() {
   const correctAnswer = useGameState((state) => state.correctAnswer);
   const incorrectAnswer = useGameState((state) => state.incorrectAnswer);
   const skipWord = useGameState((state) => state.skipWord);
+  const recordSessionActivity = useGameState((state) => state.recordSessionActivity);
 
   const [status, setStatus] = useState<QuestionStatus>('question');
   const [input, setInput] = useState('');
@@ -62,18 +63,21 @@ export default function QuestionScreen() {
   }
 
   const handleSpeak = () => {
+    recordSessionActivity();
     speak(word, language);
     inputRef.current?.focus();
   };
 
   // Track cursor position when input changes
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    recordSessionActivity();
     setInput(e.target.value);
     cursorPositionRef.current = e.target.selectionStart;
   };
 
   // Handle special character insertion
   const handleSpecialCharClick = (char: string) => {
+    recordSessionActivity();
     const position = cursorPositionRef.current !== null ? cursorPositionRef.current : input.length;
 
     // Insert the character at cursor position
@@ -100,6 +104,8 @@ export default function QuestionScreen() {
       inputRef.current?.focus();
       return;
     }
+
+    recordSessionActivity();
 
     const normalizedInput = normalizeAnswerText(input);
     const normalizedWord = normalizeAnswerText(word);
@@ -134,6 +140,8 @@ export default function QuestionScreen() {
   };
 
   const handleSkip = () => {
+    recordSessionActivity();
+
     // Show confirmation dialog before skipping
     const confirmed = confirm('Skip this word?');
     if (!confirmed) {

--- a/src/screens/results-screen.tsx
+++ b/src/screens/results-screen.tsx
@@ -5,11 +5,13 @@ import { AppShell } from '../components/app-shell';
 import { Button } from '../components/ui/button';
 import { useGameState } from '../stores/game-store';
 import { calculateWordScore, compareWordScores } from '../utils/score';
+import { formatSessionDuration } from '../utils/session-format';
 import { playCompleted } from '../utils/sounds';
 
 export default function ResultsScreen() {
   const words = useGameState((state) => state.completedWords);
   const restart = useGameState((state) => state.resetGame);
+  const session = useGameState((state) => state.session);
 
   React.useEffect(() => {
     playCompleted();
@@ -18,6 +20,8 @@ export default function ResultsScreen() {
   const totalPossibleScore = words.length * 100;
   const actualScore = words.reduce((sum, word) => sum + calculateWordScore(word), 0);
   const percentage = Math.round((actualScore / totalPossibleScore) * 100);
+  const hasSessionSummary = session.startedAt != null;
+  const sessionDuration = formatSessionDuration(session.accumulatedActiveMs);
 
   const getEmoji = (percentage: number) => {
     if (percentage === 100) return '🏆';
@@ -59,6 +63,16 @@ export default function ResultsScreen() {
                 </span>
               </div>
             </div>
+            {hasSessionSummary && (
+              <div className="rounded-[1.5rem] border border-black/10 bg-white/65 p-4 dark:border-white/10 dark:bg-white/5">
+                <div className="text-xs font-extrabold uppercase tracking-[0.28em] text-[#7d3d20] dark:text-[#f7d27a]">
+                  Time spent
+                </div>
+                <div className="mt-2 text-2xl font-black text-[#22170f] dark:text-[#f8f1e6]">
+                  {sessionDuration}
+                </div>
+              </div>
+            )}
           </div>
         </section>
 

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import type { ExerciseType, InputSource, Word, WordState } from '../types';
+import type { ExerciseType, InputSource, SessionState, Word, WordState } from '../types';
 import { shuffleArray } from '../utils/data';
 import { generateId } from '../utils/id';
 import { type Language, LANGUAGES } from '../utils/languages';
@@ -9,12 +9,96 @@ const STREAK_GOAL_AFTER_INCORRECT = 2;
 const SCHEDULE_AFTER_CORRECT = 5;
 const SCHEDULE_AFTER_INCORRECT = 0;
 
+function createInitialSessionState(): SessionState {
+  return {
+    startedAt: null,
+    endedAt: null,
+    accumulatedActiveMs: 0,
+    activeSince: null,
+    lastActivityAt: null,
+    isPaused: true,
+  };
+}
+
+function createRunningSessionState(now: number): SessionState {
+  return {
+    startedAt: now,
+    endedAt: null,
+    accumulatedActiveMs: 0,
+    activeSince: now,
+    lastActivityAt: now,
+    isPaused: false,
+  };
+}
+
+function getAccumulatedActiveMs(session: SessionState, now: number): number {
+  if (session.activeSince == null) {
+    return session.accumulatedActiveMs;
+  }
+
+  return session.accumulatedActiveMs + Math.max(0, now - session.activeSince);
+}
+
+function pauseSessionState(session: SessionState, now: number): SessionState {
+  if (session.startedAt == null || session.endedAt != null || session.isPaused) {
+    return session;
+  }
+
+  return {
+    ...session,
+    accumulatedActiveMs: getAccumulatedActiveMs(session, now),
+    activeSince: null,
+    isPaused: true,
+  };
+}
+
+function resumeSessionState(session: SessionState, now: number): SessionState {
+  if (session.startedAt == null || session.endedAt != null || !session.isPaused) {
+    return session;
+  }
+
+  return {
+    ...session,
+    activeSince: now,
+    lastActivityAt: now,
+    isPaused: false,
+  };
+}
+
+function recordSessionActivityState(session: SessionState, now: number): SessionState {
+  if (session.startedAt == null || session.endedAt != null) {
+    return session;
+  }
+
+  if (session.isPaused) {
+    return resumeSessionState(session, now);
+  }
+
+  return {
+    ...session,
+    lastActivityAt: now,
+  };
+}
+
+function finishSessionState(session: SessionState, now: number): SessionState {
+  if (session.startedAt == null || session.endedAt != null) {
+    return session;
+  }
+
+  const pausedSession = pauseSessionState(session, now);
+  return {
+    ...pausedSession,
+    endedAt: now,
+  };
+}
+
 export interface GameState {
   pendingWords: WordState[];
   completedWords: WordState[];
   language: Language;
   exerciseType: ExerciseType;
   source: InputSource;
+  session: SessionState;
 }
 
 export interface GameActions {
@@ -28,6 +112,9 @@ export interface GameActions {
   correctAnswer: (word: WordState) => void;
   incorrectAnswer: (word: WordState) => void;
   skipWord: (word: WordState) => void;
+  recordSessionActivity: () => void;
+  pauseSession: () => void;
+  resumeSession: () => void;
 }
 
 export const useGameState = create<GameState & GameActions>((set) => ({
@@ -36,8 +123,10 @@ export const useGameState = create<GameState & GameActions>((set) => ({
   language: LANGUAGES[0],
   exerciseType: 'relaxed',
   source: 'manual',
+  session: createInitialSessionState(),
 
   startGame: (words, language, exerciseType, source) => {
+    const now = Date.now();
     const initialQueue = shuffleArray(
       words.map(({ word, prompt }) => ({
         id: generateId(),
@@ -54,6 +143,7 @@ export const useGameState = create<GameState & GameActions>((set) => ({
       language,
       exerciseType,
       source,
+      session: createRunningSessionState(now),
     });
   },
 
@@ -64,11 +154,13 @@ export const useGameState = create<GameState & GameActions>((set) => ({
       language: state.language,
       exerciseType: state.exerciseType,
       source: state.source,
+      session: createInitialSessionState(),
     }));
   },
 
   correctAnswer: (word: WordState) => {
     set((state: GameState & GameActions) => {
+      const now = Date.now();
       const updatedWord = { ...word, correctStreak: word.correctStreak + 1 };
       const otherWords = state.pendingWords.filter((w) => w.id !== word.id);
 
@@ -76,10 +168,12 @@ export const useGameState = create<GameState & GameActions>((set) => ({
         updatedWord.incorrectCount === 0 ||
         updatedWord.correctStreak >= STREAK_GOAL_AFTER_INCORRECT;
       if (isCompleted) {
+        const nextCompletedWords = [...state.completedWords, updatedWord];
         return {
           ...state,
           pendingWords: otherWords,
-          completedWords: [...state.completedWords, updatedWord],
+          completedWords: nextCompletedWords,
+          session: otherWords.length === 0 ? finishSessionState(state.session, now) : state.session,
         };
       }
 
@@ -123,11 +217,36 @@ export const useGameState = create<GameState & GameActions>((set) => ({
   skipWord: (word: WordState) => {
     set((state: GameState & GameActions) => {
       const skippedWord: WordState = { ...word, skipped: true };
+      const now = Date.now();
+      const nextPendingWords = state.pendingWords.filter((w) => w.id !== word.id);
       return {
         ...state,
-        pendingWords: state.pendingWords.filter((w) => w.id !== word.id),
+        pendingWords: nextPendingWords,
         completedWords: [...state.completedWords, skippedWord],
+        session:
+          nextPendingWords.length === 0 ? finishSessionState(state.session, now) : state.session,
       };
     });
+  },
+
+  recordSessionActivity: () => {
+    set((state) => ({
+      ...state,
+      session: recordSessionActivityState(state.session, Date.now()),
+    }));
+  },
+
+  pauseSession: () => {
+    set((state) => ({
+      ...state,
+      session: pauseSessionState(state.session, Date.now()),
+    }));
+  },
+
+  resumeSession: () => {
+    set((state) => ({
+      ...state,
+      session: resumeSessionState(state.session, Date.now()),
+    }));
   },
 }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,12 @@ export interface WordState extends Word {
 }
 
 export type GameStatus = 'initial' | 'learning' | 'finished';
+
+export interface SessionState {
+  startedAt: number | null;
+  endedAt: number | null;
+  accumulatedActiveMs: number;
+  activeSince: number | null;
+  lastActivityAt: number | null;
+  isPaused: boolean;
+}

--- a/src/utils/session-format.ts
+++ b/src/utils/session-format.ts
@@ -1,0 +1,16 @@
+export function formatSessionDuration(durationMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+
+  return `${seconds}s`;
+}

--- a/src/utils/speech-service.ts
+++ b/src/utils/speech-service.ts
@@ -17,30 +17,38 @@ const ELEVENLABS_VOICE_IDS_BY_LANGUAGE: Record<string, string> = {
   'pl-PL': 'TX3LPaxmHKxFdv7VOQHJ',
   'pt-PT': 'SAz9YHcvj6GT2YYXdXww',
 };
-const ELEVENLABS_CONTEXT_BY_LANGUAGE: Record<string, { previousText: string }> = {
+const ELEVENLABS_CONTEXT_BY_LANGUAGE: Record<string, { previousText: string; nextText: string }> = {
   'de-DE': {
     previousText: 'Das nächste Wort ist auf Deutsch.',
+    nextText: '.',
   },
   'en-GB': {
     previousText: 'The next word is in British English.',
+    nextText: '.',
   },
   'en-US': {
     previousText: 'The next word is in American English.',
+    nextText: '.',
   },
   'es-ES': {
     previousText: 'La siguiente palabra está en español.',
+    nextText: '.',
   },
   'fr-FR': {
     previousText: 'Le mot suivant est en français.',
+    nextText: '.',
   },
   'it-IT': {
     previousText: 'La prossima parola è in italiano.',
+    nextText: '.',
   },
   'pl-PL': {
     previousText: 'Następne słowo jest po polsku.',
+    nextText: '.',
   },
   'pt-PT': {
     previousText: 'A próxima palavra está em português.',
+    nextText: '.',
   },
 };
 
@@ -208,6 +216,7 @@ function getElevenLabsContext(language: Language) {
   return (
     ELEVENLABS_CONTEXT_BY_LANGUAGE[language.code] ?? {
       previousText: '',
+      nextText: '.',
     }
   );
 }
@@ -241,6 +250,7 @@ async function synthesizeWithElevenLabs(request: SpeechRequest) {
         model_id: ELEVENLABS_MODEL_ID,
         language_code: getElevenLabsLanguageCode(request.language),
         previous_text: context.previousText,
+        next_text: context.nextText,
       }),
     });
 


### PR DESCRIPTION
## What does this PR do?

Adds session time tracking for quiz runs. The app now measures active practice time during the learning phase, auto-pauses after 30 seconds of inactivity or when the tab is hidden, auto-resumes on the next quiz interaction, and shows the final time spent on the results screen.

## Relevant implementation details

- Added session timing state to the Zustand game store so timing survives the transition from the question screen to results.
- Starts timing when a game begins, pauses and resumes through explicit session actions, and finalizes the session when the quiz is completed.
- Added a learning-session hook that handles inactivity timeout and `document.visibilitychange`.
- Records activity only for intentional quiz actions such as typing, submitting, replaying audio, using the special character keyboard, and skipping.
- Added tests covering session lifecycle timing, auto-pause behavior, and results rendering.

## How did you test this?

- `bun run validate`
