### PR TITLE
feat: save settings to local storage

### DIFF
--- a/src/__tests__/app.test.tsx
+++ b/src/__tests__/app.test.tsx
@@ -37,6 +37,7 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useGameState.getState().resetGame();
+    useGameState.getState().resetSetupPreferences();
   });
 
   afterEach(() => {
@@ -166,9 +167,12 @@ describe('App', () => {
           skipped: false,
         },
       ],
-      language: LANGUAGES[0],
-      exerciseType: 'strict',
-      source: 'word-set',
+      setup: {
+        ...useGameState.getState().setup,
+        languageCode: LANGUAGES[0].code,
+        exerciseType: 'strict',
+        source: 'word-set',
+      },
     });
 
     render(<App />);

--- a/src/__tests__/input-screen.test.tsx
+++ b/src/__tests__/input-screen.test.tsx
@@ -18,11 +18,7 @@ global.speechSynthesis = {
 describe('InputScreen', () => {
   beforeEach(() => {
     useGameState.getState().resetGame();
-    useGameState.setState({
-      language: LANGUAGES[0],
-      exerciseType: 'relaxed',
-      source: 'manual',
-    });
+    useGameState.getState().resetSetupPreferences();
   });
 
   it('allows user to enter words and start the game in relaxed mode', async () => {
@@ -41,8 +37,8 @@ describe('InputScreen', () => {
     const state = useGameState.getState();
     expect(state.pendingWords).toHaveLength(3);
     expect(state.pendingWords.map((word) => word.word).sort()).toEqual(['hello', 'test', 'world']);
-    expect(state.language).toEqual(LANGUAGES[0]);
-    expect(state.exerciseType).toBe('relaxed');
+    expect(state.setup.languageCode).toBe(LANGUAGES[0].code);
+    expect(state.setup.exerciseType).toBe('relaxed');
   });
 
   it('parses words with optional prompts in relaxed mode', async () => {
@@ -76,7 +72,7 @@ describe('InputScreen', () => {
     await user.click(screen.getByRole('button', { name: /Launch Mission/i }));
 
     const state = useGameState.getState();
-    expect(state.exerciseType).toBe('strict');
+    expect(state.setup.exerciseType).toBe('strict');
     expect(state.pendingWords).toHaveLength(1);
     expect(state.pendingWords[0].word).toBe('żółw');
     expect(state.pendingWords[0].prompt).toBeUndefined();
@@ -134,12 +130,150 @@ describe('InputScreen', () => {
     });
 
     const state = useGameState.getState();
-    expect(state.language.code).toBe('en-GB');
+    expect(state.setup.languageCode).toBe('en-GB');
     expect(state.pendingWords.map((word) => word.word).sort()).toEqual([
       'colour',
       'enough',
       'friend',
     ]);
+  });
+
+  it('restores saved setup preferences from local storage', async () => {
+    vi.mocked(fetch).mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/word-sets/config.json')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              id: 'en-set-1',
+              name: 'Common tricky words',
+              url: '/word-sets/en-set-1.txt',
+              languageCode: 'en-GB',
+            },
+            {
+              id: 'en-set-2',
+              name: 'Animals',
+              url: '/word-sets/en-set-2.txt',
+              languageCode: 'en-GB',
+            },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        text: async () => '',
+      } as Response;
+    });
+
+    window.localStorage.setItem(
+      'memo-bot-setup-preferences',
+      JSON.stringify({
+        state: {
+          setup: {
+            languageCode: 'en-GB',
+            exerciseType: 'strict',
+            source: 'word-set',
+            manualText: 'otter|Helpful prompt',
+            sampleSize: 25,
+            selectedWordSetId: 'en-set-2',
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await useGameState.persist.rehydrate();
+
+    render(<InputScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Word set/i })).toHaveAttribute(
+        'aria-checked',
+        'true',
+      );
+    });
+
+    expect(screen.getByRole('radio', { name: /Strict/i })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByText(LANGUAGES[0].name)).toBeInTheDocument();
+    expect(screen.getAllByText(/25 words/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Animals/i).length).toBeGreaterThan(0);
+    expect(useGameState.getState().setup.manualText).toBe('otter|Helpful prompt');
+  });
+
+  it('preserves the selected word-set size when toggling sources', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetch).mockImplementation(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith('/word-sets/config.json')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            {
+              id: 'en-set',
+              name: 'Common tricky words',
+              url: '/word-sets/en-set.txt',
+              languageCode: 'en-GB',
+            },
+          ],
+        } as Response;
+      }
+
+      return {
+        ok: false,
+        status: 404,
+        text: async () => '',
+      } as Response;
+    });
+
+    render(<InputScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('radio', { name: /Word set/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('radio', { name: /Word set/i }));
+    await user.click(screen.getByRole('button', { name: '25' }));
+    await user.click(screen.getByRole('radio', { name: /My words/i }));
+    await user.click(screen.getByRole('radio', { name: /Word set/i }));
+
+    expect(screen.getAllByText(/25 words/i).length).toBeGreaterThan(0);
+    expect(useGameState.getState().setup.sampleSize).toBe(25);
+  });
+
+  it('falls back to manual mode when saved word-set source is unavailable for the language', async () => {
+    window.localStorage.setItem(
+      'memo-bot-setup-preferences',
+      JSON.stringify({
+        state: {
+          setup: {
+            languageCode: 'pl-PL',
+            exerciseType: 'relaxed',
+            source: 'word-set',
+            manualText: 'żółw',
+            sampleSize: 10,
+            selectedWordSetId: 'missing-set',
+          },
+        },
+        version: 0,
+      }),
+    );
+
+    await useGameState.persist.rehydrate();
+
+    render(<InputScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/Enter one word per line/i)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('radio', { name: /Word set/i })).not.toBeInTheDocument();
+    expect(useGameState.getState().setup.source).toBe('manual');
+    expect(useGameState.getState().setup.selectedWordSetId).toBe('missing-set');
   });
 
   it('unmounts manual controls when the word-set source is selected', async () => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -15,6 +15,7 @@ afterEach(() => {
 });
 
 beforeEach(() => {
+  window.localStorage.clear();
   resetWordSetCache();
   resetSpeechServiceForTests();
   vi.stubGlobal(

--- a/src/__tests__/speech-service.test.tsx
+++ b/src/__tests__/speech-service.test.tsx
@@ -1,10 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AppShell } from '../components/app-shell';
+import { Toaster } from '../components/ui/toaster';
 import { LANGUAGES } from '../utils/languages';
 import { getSpeechStatusForTests, initializeSpeech, speak } from '../utils/speech-service';
 
+const ELEVENLABS_API_KEY_STORAGE_KEY = 'memo-bot-elevenlabs-api-key';
 const mockSpeechSynthesisSpeak = vi.fn();
 const mockSpeechSynthesisCancel = vi.fn();
 
@@ -67,17 +70,20 @@ describe('speech service', () => {
     window.history.pushState({}, '', '/');
   });
 
-  it('reads the hidden ElevenLabs params once and removes them from the URL', () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+  it('reads a saved ElevenLabs key from local storage during initialization', () => {
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, 'test-key');
 
     initializeSpeech();
 
-    expect(window.location.search).toBe('');
-    expect(getSpeechStatusForTests().isElevenLabsActive).toBe(true);
+    expect(getSpeechStatusForTests()).toEqual({
+      hasElevenLabsApiKey: true,
+      hasElevenLabsError: false,
+      isElevenLabsActive: true,
+    });
   });
 
   it('reuses cached ElevenLabs audio for the same locale and text', async () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, 'test-key');
     initializeSpeech();
 
     vi.mocked(fetch).mockResolvedValue(
@@ -101,7 +107,7 @@ describe('speech service', () => {
   });
 
   it('uses the mapped Polish voice and forces the Polish language code', async () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, 'test-key');
     initializeSpeech();
 
     vi.mocked(fetch).mockResolvedValue(
@@ -122,8 +128,8 @@ describe('speech service', () => {
     expect(requestInit.body).toContain('"next_text":"."');
   });
 
-  it('uses the per-language mapped voice when no explicit voice id is configured', async () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
+  it('uses the per-language mapped voice', async () => {
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, 'test-key');
     initializeSpeech();
 
     vi.mocked(fetch).mockResolvedValue(
@@ -138,24 +144,6 @@ describe('speech service', () => {
 
     const [requestUrl] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
     expect(requestUrl).toContain('/JBFqnCBsd6RMkjVDRZzb');
-  });
-
-  it('prefers an explicitly configured voice id over the per-language mapping', async () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
-    initializeSpeech();
-
-    vi.mocked(fetch).mockResolvedValue(
-      new Response(new Blob(['audio'], { type: 'audio/mpeg' }), { status: 200 }),
-    );
-
-    speak('friend', LANGUAGES[0]);
-
-    await waitFor(() => {
-      expect(fetch).toHaveBeenCalledTimes(1);
-    });
-
-    const [requestUrl] = vi.mocked(fetch).mock.calls[0] as [string, RequestInit];
-    expect(requestUrl).toContain('/voice-123');
   });
 
   it('queues only the newest request while browser speech is in progress', async () => {
@@ -178,10 +166,19 @@ describe('speech service', () => {
   });
 
   it('disables ElevenLabs after a hard failure and falls back to browser speech', async () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key&elevenlabs-voice-id=voice-123');
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, 'test-key');
     initializeSpeech();
 
     vi.mocked(fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+    render(
+      <>
+        <AppShell>
+          <div>child</div>
+        </AppShell>
+        <Toaster />
+      </>,
+    );
 
     speak('kot', LANGUAGES[7]);
 
@@ -189,7 +186,12 @@ describe('speech service', () => {
       expect(mockSpeechSynthesisSpeak).toHaveBeenCalledTimes(1);
     });
 
-    expect(getSpeechStatusForTests().isElevenLabsActive).toBe(false);
+    expect(getSpeechStatusForTests()).toEqual({
+      hasElevenLabsApiKey: true,
+      hasElevenLabsError: true,
+      isElevenLabsActive: false,
+    });
+    expect(screen.getByText('ElevenLabs TTS needs attention')).toBeInTheDocument();
 
     const firstUtterance = vi.mocked(SpeechSynthesisUtterance).mock.results[0]
       .value as MockUtterance;
@@ -203,9 +205,8 @@ describe('speech service', () => {
     });
   });
 
-  it('shows the active badge only when ElevenLabs is enabled for new requests', () => {
-    window.history.pushState({}, '', '/?elevenlabs-api-key=test-key');
-    initializeSpeech();
+  it('saves and removes the ElevenLabs key from the TTS dialog without showing the current value', async () => {
+    const user = userEvent.setup();
 
     render(
       <AppShell>
@@ -213,6 +214,25 @@ describe('speech service', () => {
       </AppShell>,
     );
 
-    expect(screen.getByText('ElevenLabs TTS')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /Open TTS settings/i }));
+    expect(screen.getByText('No key configured')).toBeInTheDocument();
+
+    const input = screen.getByLabelText(/New API key/i);
+    await user.type(input, 'super-secret-key');
+    await user.click(screen.getByRole('button', { name: /Save key/i }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(ELEVENLABS_API_KEY_STORAGE_KEY)).toBe('super-secret-key');
+    });
+
+    await user.click(screen.getByRole('button', { name: /Open TTS settings/i }));
+    expect(screen.getByText('Key configured on this device')).toBeInTheDocument();
+    expect(screen.getByLabelText(/New API key/i)).toHaveValue('');
+
+    await user.click(screen.getByRole('button', { name: /Remove key/i }));
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem(ELEVENLABS_API_KEY_STORAGE_KEY)).toBeNull();
+    });
   });
 });

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,9 +1,25 @@
-import { Moon, Sun } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { Moon, Sun, Volume2 } from 'lucide-react';
+import { useEffect, useId, useState } from 'react';
 import type { ReactNode } from 'react';
 
+import { toast } from '../hooks/use-toast';
 import { cn } from '../lib/utils';
-import { useSpeechStatus } from '../utils/speech-service';
+import {
+  clearElevenLabsApiKey,
+  setElevenLabsApiKey,
+  useSpeechStatus,
+} from '../utils/speech-service';
+import { Button } from './ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
 import { Toggle } from './ui/toggle';
 
 type AppShellProps = {
@@ -13,7 +29,10 @@ type AppShellProps = {
 
 export function AppShell({ children, className }: AppShellProps) {
   const [isDark, setIsDark] = useState(false);
-  const { isElevenLabsActive } = useSpeechStatus();
+  const [isTtsDialogOpen, setIsTtsDialogOpen] = useState(false);
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const { hasElevenLabsApiKey, hasElevenLabsError, isElevenLabsActive } = useSpeechStatus();
+  const apiKeyInputId = useId();
 
   useEffect(() => {
     const storedTheme = window.localStorage.getItem('memo-bot-theme');
@@ -26,6 +45,54 @@ export function AppShell({ children, className }: AppShellProps) {
     setIsDark(pressed);
     document.documentElement.classList.toggle('dark', pressed);
     window.localStorage.setItem('memo-bot-theme', pressed ? 'dark' : 'light');
+  };
+
+  useEffect(() => {
+    if (isTtsDialogOpen) {
+      setApiKeyInput('');
+    }
+  }, [isTtsDialogOpen]);
+
+  const ttsStatusLabel = hasElevenLabsError
+    ? 'Saved key needs attention'
+    : hasElevenLabsApiKey
+      ? 'Key configured on this device'
+      : 'No key configured';
+  const ttsButtonClassName = hasElevenLabsError
+    ? 'border-amber-400/50 bg-amber-100/80 text-amber-900 hover:bg-amber-100 dark:border-amber-300/25 dark:bg-amber-300/10 dark:text-amber-100 dark:hover:bg-amber-300/15'
+    : isElevenLabsActive
+      ? 'border-emerald-500/35 bg-emerald-100/80 text-emerald-900 hover:bg-emerald-100 dark:border-emerald-300/25 dark:bg-emerald-300/10 dark:text-emerald-100 dark:hover:bg-emerald-300/15'
+      : 'border-black/10 bg-white/75 text-[#5b4636] hover:bg-white dark:border-white/10 dark:bg-[rgba(255,255,255,0.08)] dark:text-[#d4c5b3] dark:hover:bg-[rgba(255,255,255,0.12)]';
+
+  const handleSaveTtsKey = () => {
+    const nextApiKey = apiKeyInput.trim();
+    if (!nextApiKey) {
+      return;
+    }
+
+    if (!setElevenLabsApiKey(nextApiKey)) {
+      toast({
+        title: 'Could not save ElevenLabs key',
+        description: 'Please try again on this device.',
+      });
+      return;
+    }
+
+    setIsTtsDialogOpen(false);
+    setApiKeyInput('');
+  };
+
+  const handleRemoveTtsKey = () => {
+    if (!clearElevenLabsApiKey()) {
+      toast({
+        title: 'Could not remove ElevenLabs key',
+        description: 'Please try again on this device.',
+      });
+      return;
+    }
+
+    setIsTtsDialogOpen(false);
+    setApiKeyInput('');
   };
 
   return (
@@ -44,7 +111,31 @@ export function AppShell({ children, className }: AppShellProps) {
         )}
       >
         <div className="fixed right-4 top-4 z-30 flex items-center justify-end gap-2 sm:right-6 lg:right-10">
-          {isElevenLabsActive && <div className="eyebrow">ElevenLabs TTS</div>}
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            aria-label="Open TTS settings"
+            onClick={() => setIsTtsDialogOpen(true)}
+            className={cn(
+              'h-10 rounded-full px-3 text-sm font-semibold shadow-sm transition-colors',
+              ttsButtonClassName,
+            )}
+          >
+            <Volume2 className="h-4 w-4" />
+            <span>TTS</span>
+            <span
+              aria-hidden="true"
+              className={cn(
+                'h-2.5 w-2.5 rounded-full',
+                hasElevenLabsError
+                  ? 'bg-amber-500'
+                  : isElevenLabsActive
+                    ? 'bg-emerald-500'
+                    : 'bg-[#b89f8a] dark:bg-[#6f6558]',
+              )}
+            />
+          </Button>
           <Toggle
             pressed={isDark}
             onPressedChange={handleThemeChange}
@@ -56,6 +147,70 @@ export function AppShell({ children, className }: AppShellProps) {
             <span>{isDark ? 'Dark' : 'Light'}</span>
           </Toggle>
         </div>
+        <Dialog open={isTtsDialogOpen} onOpenChange={setIsTtsDialogOpen}>
+          <DialogContent className="rounded-[1.75rem] border-black/10 bg-[rgba(255,251,245,0.98)] sm:max-w-md dark:border-white/10 dark:bg-[rgba(29,34,46,0.98)]">
+            <DialogHeader className="space-y-2 text-left">
+              <DialogTitle className="text-2xl font-black text-[#22170f] dark:text-[#f8f1e6]">
+                ElevenLabs TTS
+              </DialogTitle>
+              <DialogDescription className="text-sm font-medium text-[#5b4636] dark:text-[#d4c5b3]">
+                Add a key to use ElevenLabs voice playback on this device. The key stays in local
+                storage and is never shown back to you here.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4">
+              <div
+                className={cn(
+                  'rounded-[1.2rem] border px-4 py-3 text-sm font-semibold',
+                  hasElevenLabsError
+                    ? 'border-amber-500/30 bg-amber-100/75 text-amber-900 dark:border-amber-300/20 dark:bg-amber-300/10 dark:text-amber-100'
+                    : hasElevenLabsApiKey
+                      ? 'border-emerald-500/25 bg-emerald-100/70 text-emerald-900 dark:border-emerald-300/20 dark:bg-emerald-300/10 dark:text-emerald-100'
+                      : 'border-black/10 bg-white/70 text-[#5b4636] dark:border-white/10 dark:bg-white/5 dark:text-[#d4c5b3]',
+                )}
+              >
+                {ttsStatusLabel}
+              </div>
+
+              <div className="space-y-2">
+                <Label
+                  htmlFor={apiKeyInputId}
+                  className="text-sm font-extrabold uppercase tracking-[0.22em] text-[#7d3d20] dark:text-[#f7d27a]"
+                >
+                  New API key
+                </Label>
+                <Input
+                  id={apiKeyInputId}
+                  type="password"
+                  value={apiKeyInput}
+                  onChange={(event) => setApiKeyInput(event.target.value)}
+                  placeholder="Paste ElevenLabs API key"
+                  autoComplete="off"
+                  className="h-12 rounded-[1rem] border-black/10 bg-white/80 text-base dark:border-white/10 dark:bg-white/5"
+                />
+              </div>
+            </div>
+
+            <DialogFooter className="gap-2 sm:justify-between sm:space-x-0">
+              <div className="flex justify-start">
+                {hasElevenLabsApiKey && (
+                  <Button type="button" variant="ghost" onClick={handleRemoveTtsKey}>
+                    Remove key
+                  </Button>
+                )}
+              </div>
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <Button type="button" variant="outline" onClick={() => setIsTtsDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button type="button" onClick={handleSaveTtsKey} disabled={!apiKeyInput.trim()}>
+                  Save key
+                </Button>
+              </div>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
         {children}
       </div>
     </div>

--- a/src/screens/input-screen.tsx
+++ b/src/screens/input-screen.tsx
@@ -20,9 +20,11 @@ import { toast } from '../hooks/use-toast';
 import { cn } from '../lib/utils';
 import { useGameState } from '../stores/game-store';
 import type { ExerciseType, InputSource, Word } from '../types';
+import { getLanguageByCode } from '../utils/languages';
 import { normalizeInputText } from '../utils/text-normalization';
 import {
   type WordSetConfig,
+  type WordSetSampleSize,
   getWordSetConfigs,
   getWordSetWords,
   sampleWordSetWords,
@@ -30,18 +32,20 @@ import {
 } from '../utils/word-sets';
 
 type WordSetLoadState = 'loading' | 'ready' | 'error';
-type SampleSize = (typeof WORD_SET_SAMPLE_SIZES)[number];
 
 export default function InputScreen() {
-  const savedLanguage = useGameState((state) => state.language);
-  const savedExerciseType = useGameState((state) => state.exerciseType);
-  const savedSource = useGameState((state) => state.source);
-  const [text, setText] = useState('');
-  const [language, setLanguage] = useState(savedLanguage);
-  const [exerciseType, setExerciseType] = useState<ExerciseType>(savedExerciseType);
-  const [source, setSource] = useState<InputSource>(savedSource);
-  const [sampleSize, setSampleSize] = useState<SampleSize>(WORD_SET_SAMPLE_SIZES[0]);
-  const [selectedWordSetId, setSelectedWordSetId] = useState('');
+  const language = useGameState((state) => getLanguageByCode(state.setup.languageCode));
+  const exerciseType = useGameState((state) => state.setup.exerciseType);
+  const source = useGameState((state) => state.setup.source);
+  const text = useGameState((state) => state.setup.manualText);
+  const sampleSize = useGameState((state) => state.setup.sampleSize);
+  const selectedWordSetId = useGameState((state) => state.setup.selectedWordSetId);
+  const setLanguage = useGameState((state) => state.setLanguage);
+  const setExerciseType = useGameState((state) => state.setExerciseType);
+  const setSource = useGameState((state) => state.setSource);
+  const setManualText = useGameState((state) => state.setManualText);
+  const setSampleSize = useGameState((state) => state.setSampleSize);
+  const setSelectedWordSetId = useGameState((state) => state.setSelectedWordSetId);
   const [wordSetConfigs, setWordSetConfigs] = useState<WordSetConfig[]>([]);
   const [wordSetLoadState, setWordSetLoadState] = useState<WordSetLoadState>('loading');
   const [isStartingWordSet, setIsStartingWordSet] = useState(false);
@@ -86,21 +90,31 @@ export default function InputScreen() {
         return;
       }
 
-      setSource('manual');
-      setSelectedWordSetId('');
+      if (source !== 'manual') {
+        setSource('manual');
+      }
       return;
     }
 
-    setSelectedWordSetId((currentId) => {
-      const matchingWordSet = availableWordSets.find((config) => config.id === currentId);
-      return matchingWordSet?.id ?? availableWordSets[0].id;
-    });
-  }, [availableWordSets, wordSetLoadState]);
+    const nextSelectedWordSetId =
+      availableWordSets.find((config) => config.id === selectedWordSetId)?.id ??
+      availableWordSets[0].id;
+
+    if (nextSelectedWordSetId !== selectedWordSetId) {
+      setSelectedWordSetId(nextSelectedWordSetId);
+    }
+  }, [
+    availableWordSets,
+    selectedWordSetId,
+    setSelectedWordSetId,
+    setSource,
+    source,
+    wordSetLoadState,
+  ]);
 
   const handleSourceChange = (nextSource: InputSource) => {
-    if (nextSource === 'word-set') {
-      setSampleSize(WORD_SET_SAMPLE_SIZES[0]);
-      setSelectedWordSetId((currentId) => currentId || availableWordSets[0]?.id || '');
+    if (nextSource === 'word-set' && !selectedWordSetId) {
+      setSelectedWordSetId(availableWordSets[0]?.id || '');
     }
 
     setSource(nextSource);
@@ -229,7 +243,7 @@ export default function InputScreen() {
                 <div className="space-y-4 pb-1">
                   <Textarea
                     value={text}
-                    onChange={(e) => setText(e.target.value)}
+                    onChange={(e) => setManualText(e.target.value)}
                     placeholder={`Enter one word per line...\nYou can also add an optional prompt with |`}
                     className="min-h-[260px] rounded-[1.5rem] border-black/10 bg-white/80 px-5 py-4 text-lg leading-8 text-[#2f2218] placeholder:text-[#9d8a79] shadow-[inset_0_1px_0_rgba(255,255,255,0.55)] focus-visible:ring-inset focus-visible:ring-[#de5a37] focus-visible:ring-offset-0 dark:border-white/10 dark:bg-[rgba(19,23,32,0.82)] dark:text-[#f3eadf] dark:placeholder:text-[#8b8f9a] dark:shadow-none"
                   />
@@ -312,7 +326,8 @@ export default function InputScreen() {
                           step={1}
                           onValueChange={([nextIndex]) => {
                             setSampleSize(
-                              WORD_SET_SAMPLE_SIZES[nextIndex] ?? WORD_SET_SAMPLE_SIZES[0],
+                              (WORD_SET_SAMPLE_SIZES[nextIndex] ??
+                                WORD_SET_SAMPLE_SIZES[0]) as WordSetSampleSize,
                             );
                           }}
                           className="relative z-10"

--- a/src/screens/question-screen.tsx
+++ b/src/screens/question-screen.tsx
@@ -9,6 +9,7 @@ import { Input } from '../components/ui/input';
 import { WordDiff } from '../components/word-diff';
 import { useGameState } from '../stores/game-store';
 import { useCurrentWord } from '../stores/selectors';
+import { getLanguageByCode } from '../utils/languages';
 import { playCorrect } from '../utils/sounds';
 import { speak } from '../utils/speak';
 import { normalizeAnswerText } from '../utils/text-normalization';
@@ -19,8 +20,8 @@ type QuestionStatus = 'question' | 'retry' | 'correct';
 
 export default function QuestionScreen() {
   const currentWord = useCurrentWord();
-  const language = useGameState((state) => state.language);
-  const exerciseType = useGameState((state) => state.exerciseType);
+  const language = useGameState((state) => getLanguageByCode(state.setup.languageCode));
+  const exerciseType = useGameState((state) => state.setup.exerciseType);
   const remaining = useGameState((state) => state.pendingWords.length);
   const completed = useGameState((state) => state.completedWords.length);
   const correctAnswer = useGameState((state) => state.correctAnswer);

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -1,13 +1,25 @@
 import { create } from 'zustand';
+import { createJSONStorage, persist } from 'zustand/middleware';
 
 import type { ExerciseType, InputSource, SessionState, Word, WordState } from '../types';
 import { shuffleArray } from '../utils/data';
 import { generateId } from '../utils/id';
-import { type Language, LANGUAGES } from '../utils/languages';
+import { type Language, LANGUAGES, isSupportedLanguageCode } from '../utils/languages';
+import { WORD_SET_SAMPLE_SIZES, type WordSetSampleSize } from '../utils/word-sets';
 
 const STREAK_GOAL_AFTER_INCORRECT = 2;
 const SCHEDULE_AFTER_CORRECT = 5;
 const SCHEDULE_AFTER_INCORRECT = 0;
+const STORE_PERSISTENCE_KEY = 'memo-bot-setup-preferences';
+
+export interface SetupPreferences {
+  languageCode: string;
+  exerciseType: ExerciseType;
+  source: InputSource;
+  manualText: string;
+  sampleSize: WordSetSampleSize;
+  selectedWordSetId: string;
+}
 
 function createInitialSessionState(): SessionState {
   return {
@@ -92,12 +104,62 @@ function finishSessionState(session: SessionState, now: number): SessionState {
   };
 }
 
+function createInitialSetupPreferences(): SetupPreferences {
+  return {
+    languageCode: LANGUAGES[0].code,
+    exerciseType: 'relaxed',
+    source: 'manual',
+    manualText: '',
+    sampleSize: WORD_SET_SAMPLE_SIZES[0],
+    selectedWordSetId: '',
+  };
+}
+
+function isExerciseType(value: unknown): value is ExerciseType {
+  return value === 'relaxed' || value === 'strict';
+}
+
+function isInputSource(value: unknown): value is InputSource {
+  return value === 'manual' || value === 'word-set';
+}
+
+function isWordSetSampleSize(value: unknown): value is WordSetSampleSize {
+  return typeof value === 'number' && WORD_SET_SAMPLE_SIZES.includes(value as WordSetSampleSize);
+}
+
+function sanitizeSetupPreferences(value: unknown): SetupPreferences {
+  const defaults = createInitialSetupPreferences();
+  if (typeof value !== 'object' || value === null) {
+    return defaults;
+  }
+
+  const persisted = value as Record<string, unknown>;
+
+  return {
+    languageCode:
+      typeof persisted.languageCode === 'string' && isSupportedLanguageCode(persisted.languageCode)
+        ? persisted.languageCode
+        : defaults.languageCode,
+    exerciseType: isExerciseType(persisted.exerciseType)
+      ? persisted.exerciseType
+      : defaults.exerciseType,
+    source: isInputSource(persisted.source) ? persisted.source : defaults.source,
+    manualText:
+      typeof persisted.manualText === 'string' ? persisted.manualText : defaults.manualText,
+    sampleSize: isWordSetSampleSize(persisted.sampleSize)
+      ? persisted.sampleSize
+      : defaults.sampleSize,
+    selectedWordSetId:
+      typeof persisted.selectedWordSetId === 'string'
+        ? persisted.selectedWordSetId
+        : defaults.selectedWordSetId,
+  };
+}
+
 export interface GameState {
   pendingWords: WordState[];
   completedWords: WordState[];
-  language: Language;
-  exerciseType: ExerciseType;
-  source: InputSource;
+  setup: SetupPreferences;
   session: SessionState;
 }
 
@@ -109,6 +171,13 @@ export interface GameActions {
     source: InputSource,
   ) => void;
   resetGame: () => void;
+  resetSetupPreferences: () => void;
+  setLanguage: (language: Language) => void;
+  setExerciseType: (exerciseType: ExerciseType) => void;
+  setSource: (source: InputSource) => void;
+  setManualText: (text: string) => void;
+  setSampleSize: (sampleSize: WordSetSampleSize) => void;
+  setSelectedWordSetId: (wordSetId: string) => void;
   correctAnswer: (word: WordState) => void;
   incorrectAnswer: (word: WordState) => void;
   skipWord: (word: WordState) => void;
@@ -117,136 +186,225 @@ export interface GameActions {
   resumeSession: () => void;
 }
 
-export const useGameState = create<GameState & GameActions>((set) => ({
-  pendingWords: [],
-  completedWords: [],
-  language: LANGUAGES[0],
-  exerciseType: 'relaxed',
-  source: 'manual',
-  session: createInitialSessionState(),
-
-  startGame: (words, language, exerciseType, source) => {
-    const now = Date.now();
-    const initialQueue = shuffleArray(
-      words.map(({ word, prompt }) => ({
-        id: generateId(),
-        word,
-        prompt,
-        correctStreak: 0,
-        incorrectCount: 0,
-      })),
-    );
-
-    set({
-      pendingWords: initialQueue,
-      completedWords: [],
-      language,
-      exerciseType,
-      source,
-      session: createRunningSessionState(now),
-    });
-  },
-
-  resetGame: () => {
-    set((state) => ({
+export const useGameState = create<GameState & GameActions>()(
+  persist(
+    (set) => ({
       pendingWords: [],
       completedWords: [],
-      language: state.language,
-      exerciseType: state.exerciseType,
-      source: state.source,
+      setup: createInitialSetupPreferences(),
       session: createInitialSessionState(),
-    }));
-  },
 
-  correctAnswer: (word: WordState) => {
-    set((state: GameState & GameActions) => {
-      const now = Date.now();
-      const updatedWord = { ...word, correctStreak: word.correctStreak + 1 };
-      const otherWords = state.pendingWords.filter((w) => w.id !== word.id);
+      startGame: (words, language, exerciseType, source) => {
+        const now = Date.now();
+        const initialQueue = shuffleArray(
+          words.map(({ word, prompt }) => ({
+            id: generateId(),
+            word,
+            prompt,
+            correctStreak: 0,
+            incorrectCount: 0,
+          })),
+        );
 
-      const isCompleted =
-        updatedWord.incorrectCount === 0 ||
-        updatedWord.correctStreak >= STREAK_GOAL_AFTER_INCORRECT;
-      if (isCompleted) {
-        const nextCompletedWords = [...state.completedWords, updatedWord];
-        return {
+        set((state) => ({
+          pendingWords: initialQueue,
+          completedWords: [],
+          setup: {
+            ...state.setup,
+            languageCode: language.code,
+            exerciseType,
+            source,
+          },
+          session: createRunningSessionState(now),
+        }));
+      },
+
+      resetGame: () => {
+        set((state) => ({
+          pendingWords: [],
+          completedWords: [],
+          setup: state.setup,
+          session: createInitialSessionState(),
+        }));
+      },
+
+      resetSetupPreferences: () => {
+        set((state) => ({
           ...state,
-          pendingWords: otherWords,
-          completedWords: nextCompletedWords,
-          session: otherWords.length === 0 ? finishSessionState(state.session, now) : state.session,
-        };
-      }
+          setup: createInitialSetupPreferences(),
+        }));
+      },
 
-      const insertPosition = Math.min(SCHEDULE_AFTER_CORRECT, otherWords.length);
-      otherWords.splice(insertPosition, 0, updatedWord);
-
-      return {
-        ...state,
-        pendingWords: otherWords,
-      };
-    });
-  },
-
-  incorrectAnswer: (word: WordState) => {
-    set((state) => {
-      const otherWords = state.pendingWords.filter((w) => w.id !== word.id);
-      const updatedWord: WordState = {
-        ...word,
-        correctStreak: 0,
-        incorrectCount: word.incorrectCount + 1,
-      };
-
-      // In the first pass, go through all words. In subsequent passes, schedule the repetition closer.
-      const isFirstAttempt = word.incorrectCount === 0;
-      if (isFirstAttempt) {
-        return {
+      setLanguage: (language) => {
+        set((state) => ({
           ...state,
-          pendingWords: [...otherWords, updatedWord],
+          setup: {
+            ...state.setup,
+            languageCode: language.code,
+          },
+        }));
+      },
+
+      setExerciseType: (exerciseType) => {
+        set((state) => ({
+          ...state,
+          setup: {
+            ...state.setup,
+            exerciseType,
+          },
+        }));
+      },
+
+      setSource: (source) => {
+        set((state) => ({
+          ...state,
+          setup: {
+            ...state.setup,
+            source,
+          },
+        }));
+      },
+
+      setManualText: (manualText) => {
+        set((state) => ({
+          ...state,
+          setup: {
+            ...state.setup,
+            manualText,
+          },
+        }));
+      },
+
+      setSampleSize: (sampleSize) => {
+        set((state) => ({
+          ...state,
+          setup: {
+            ...state.setup,
+            sampleSize,
+          },
+        }));
+      },
+
+      setSelectedWordSetId: (selectedWordSetId) => {
+        set((state) => ({
+          ...state,
+          setup: {
+            ...state.setup,
+            selectedWordSetId,
+          },
+        }));
+      },
+
+      correctAnswer: (word: WordState) => {
+        set((state: GameState & GameActions) => {
+          const now = Date.now();
+          const updatedWord = { ...word, correctStreak: word.correctStreak + 1 };
+          const otherWords = state.pendingWords.filter((w) => w.id !== word.id);
+
+          const isCompleted =
+            updatedWord.incorrectCount === 0 ||
+            updatedWord.correctStreak >= STREAK_GOAL_AFTER_INCORRECT;
+          if (isCompleted) {
+            const nextCompletedWords = [...state.completedWords, updatedWord];
+            return {
+              ...state,
+              pendingWords: otherWords,
+              completedWords: nextCompletedWords,
+              session:
+                otherWords.length === 0 ? finishSessionState(state.session, now) : state.session,
+            };
+          }
+
+          const insertPosition = Math.min(SCHEDULE_AFTER_CORRECT, otherWords.length);
+          otherWords.splice(insertPosition, 0, updatedWord);
+
+          return {
+            ...state,
+            pendingWords: otherWords,
+          };
+        });
+      },
+
+      incorrectAnswer: (word: WordState) => {
+        set((state) => {
+          const otherWords = state.pendingWords.filter((w) => w.id !== word.id);
+          const updatedWord: WordState = {
+            ...word,
+            correctStreak: 0,
+            incorrectCount: word.incorrectCount + 1,
+          };
+
+          // In the first pass, go through all words. In subsequent passes, schedule the repetition closer.
+          const isFirstAttempt = word.incorrectCount === 0;
+          if (isFirstAttempt) {
+            return {
+              ...state,
+              pendingWords: [...otherWords, updatedWord],
+            };
+          }
+
+          const insertPosition = Math.min(SCHEDULE_AFTER_INCORRECT, otherWords.length);
+          otherWords.splice(insertPosition, 0, updatedWord);
+          return {
+            ...state,
+            pendingWords: otherWords,
+          };
+        });
+      },
+
+      skipWord: (word: WordState) => {
+        set((state: GameState & GameActions) => {
+          const skippedWord: WordState = { ...word, skipped: true };
+          const now = Date.now();
+          const nextPendingWords = state.pendingWords.filter((w) => w.id !== word.id);
+          return {
+            ...state,
+            pendingWords: nextPendingWords,
+            completedWords: [...state.completedWords, skippedWord],
+            session:
+              nextPendingWords.length === 0
+                ? finishSessionState(state.session, now)
+                : state.session,
+          };
+        });
+      },
+
+      recordSessionActivity: () => {
+        set((state) => ({
+          ...state,
+          session: recordSessionActivityState(state.session, Date.now()),
+        }));
+      },
+
+      pauseSession: () => {
+        set((state) => ({
+          ...state,
+          session: pauseSessionState(state.session, Date.now()),
+        }));
+      },
+
+      resumeSession: () => {
+        set((state) => ({
+          ...state,
+          session: resumeSessionState(state.session, Date.now()),
+        }));
+      },
+    }),
+    {
+      name: STORE_PERSISTENCE_KEY,
+      storage: createJSONStorage(() => window.localStorage),
+      partialize: (state) => ({
+        setup: state.setup,
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<GameState> | undefined;
+        const current = currentState as GameState & GameActions;
+
+        return {
+          ...current,
+          setup: sanitizeSetupPreferences(persisted?.setup),
         };
-      }
-
-      const insertPosition = Math.min(SCHEDULE_AFTER_INCORRECT, otherWords.length);
-      otherWords.splice(insertPosition, 0, updatedWord);
-      return {
-        ...state,
-        pendingWords: otherWords,
-      };
-    });
-  },
-
-  skipWord: (word: WordState) => {
-    set((state: GameState & GameActions) => {
-      const skippedWord: WordState = { ...word, skipped: true };
-      const now = Date.now();
-      const nextPendingWords = state.pendingWords.filter((w) => w.id !== word.id);
-      return {
-        ...state,
-        pendingWords: nextPendingWords,
-        completedWords: [...state.completedWords, skippedWord],
-        session:
-          nextPendingWords.length === 0 ? finishSessionState(state.session, now) : state.session,
-      };
-    });
-  },
-
-  recordSessionActivity: () => {
-    set((state) => ({
-      ...state,
-      session: recordSessionActivityState(state.session, Date.now()),
-    }));
-  },
-
-  pauseSession: () => {
-    set((state) => ({
-      ...state,
-      session: pauseSessionState(state.session, Date.now()),
-    }));
-  },
-
-  resumeSession: () => {
-    set((state) => ({
-      ...state,
-      session: resumeSessionState(state.session, Date.now()),
-    }));
-  },
-}));
+      },
+    },
+  ),
+);

--- a/src/utils/languages.ts
+++ b/src/utils/languages.ts
@@ -15,3 +15,11 @@ export const LANGUAGES: Language[] = [
   { code: 'pt-PT', name: 'Portuguese', voice: 'pt-PT', flag: '🇵🇹' },
   { code: 'pl-PL', name: 'Polish', voice: 'pl-PL', flag: '🇵🇱' },
 ];
+
+export function getLanguageByCode(code: string): Language {
+  return LANGUAGES.find((language) => language.code === code) ?? LANGUAGES[0];
+}
+
+export function isSupportedLanguageCode(code: string): boolean {
+  return LANGUAGES.some((language) => language.code === code);
+}

--- a/src/utils/speech-service.ts
+++ b/src/utils/speech-service.ts
@@ -1,11 +1,11 @@
 import { useSyncExternalStore } from 'react';
 
+import { toast } from '../hooks/use-toast';
 import type { Language } from './languages';
 
-const ELEVENLABS_API_KEY_PARAM = 'elevenlabs-api-key';
-const ELEVENLABS_VOICE_ID_PARAM = 'elevenlabs-voice-id';
 const ELEVENLABS_MODEL_ID = 'eleven_multilingual_v2';
 const ELEVENLABS_TTS_URL = 'https://api.elevenlabs.io/v1/text-to-speech';
+const ELEVENLABS_API_KEY_STORAGE_KEY = 'memo-bot-elevenlabs-api-key';
 const DEFAULT_ELEVENLABS_VOICE_ID = 'TX3LPaxmHKxFdv7VOQHJ';
 const ELEVENLABS_VOICE_IDS_BY_LANGUAGE: Record<string, string> = {
   'de-DE': 'TX3LPaxmHKxFdv7VOQHJ',
@@ -58,6 +58,8 @@ type SpeechRequest = {
 };
 
 type SpeechStatus = {
+  hasElevenLabsApiKey: boolean;
+  hasElevenLabsError: boolean;
   isElevenLabsActive: boolean;
 };
 
@@ -70,18 +72,21 @@ const speechCache = new Map<string, SpeechCacheEntry>();
 
 let hasInitialized = false;
 let elevenLabsApiKey: string | null = null;
-let configuredVoiceId: string | null = null;
 let isElevenLabsDisabled = false;
 let currentPlaybackToken: number | null = null;
 let currentAudio: HTMLAudioElement | null = null;
 let queuedRequest: SpeechRequest | null = null;
 let nextPlaybackToken = 0;
 let speechStatus: SpeechStatus = {
+  hasElevenLabsApiKey: false,
+  hasElevenLabsError: false,
   isElevenLabsActive: false,
 };
 
 function emitStatusChange() {
   speechStatus = {
+    hasElevenLabsApiKey: elevenLabsApiKey != null,
+    hasElevenLabsError: elevenLabsApiKey != null && isElevenLabsDisabled,
     isElevenLabsActive: elevenLabsApiKey != null && !isElevenLabsDisabled,
   };
   listeners.forEach((listener) => listener());
@@ -99,17 +104,39 @@ function subscribeToSpeechStatus(listener: () => void) {
   };
 }
 
+function canRequestElevenLabs() {
+  return elevenLabsApiKey != null && !isElevenLabsDisabled;
+}
+
 function getCacheKey({ language, text }: SpeechRequest) {
   return `${language.code}::${text}`;
 }
 
-function getUrlWithoutHiddenParams(url: URL) {
-  const nextSearch = url.searchParams.toString();
-  return `${url.pathname}${nextSearch ? `?${nextSearch}` : ''}${url.hash}`;
+function clearSpeechCache() {
+  for (const entry of speechCache.values()) {
+    URL.revokeObjectURL?.(entry.objectUrl);
+  }
+
+  speechCache.clear();
 }
 
-function canRequestElevenLabs() {
-  return elevenLabsApiKey != null && !isElevenLabsDisabled;
+function setApiKeyState(apiKey: string | null) {
+  elevenLabsApiKey = apiKey;
+  isElevenLabsDisabled = false;
+  clearSpeechCache();
+  emitStatusChange();
+}
+
+function readStoredApiKey() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage.getItem(ELEVENLABS_API_KEY_STORAGE_KEY)?.trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 function finishPlayback(playbackToken: number) {
@@ -181,6 +208,11 @@ function disableElevenLabs() {
 
   isElevenLabsDisabled = true;
   emitStatusChange();
+  toast({
+    title: 'ElevenLabs TTS needs attention',
+    description:
+      'The saved key was rejected or ran out of credits. Update or remove it in TTS settings.',
+  });
 }
 
 async function readErrorText(response: Response) {
@@ -205,11 +237,7 @@ function getElevenLabsLanguageCode(language: Language) {
 }
 
 function getElevenLabsVoiceId(language: Language) {
-  return (
-    configuredVoiceId ??
-    ELEVENLABS_VOICE_IDS_BY_LANGUAGE[language.code] ??
-    DEFAULT_ELEVENLABS_VOICE_ID
-  );
+  return ELEVENLABS_VOICE_IDS_BY_LANGUAGE[language.code] ?? DEFAULT_ELEVENLABS_VOICE_ID;
 }
 
 function getElevenLabsContext(language: Language) {
@@ -274,14 +302,14 @@ async function playSpeechRequest(request: SpeechRequest) {
   const playbackToken = ++nextPlaybackToken;
   currentPlaybackToken = playbackToken;
 
-  const cachedAudio = speechCache.get(getCacheKey(request));
-  if (cachedAudio != null) {
-    playObjectUrl(cachedAudio.objectUrl, playbackToken);
+  if (!canRequestElevenLabs()) {
+    playWithBrowserSpeech(request, playbackToken);
     return;
   }
 
-  if (!canRequestElevenLabs()) {
-    playWithBrowserSpeech(request, playbackToken);
+  const cachedAudio = speechCache.get(getCacheKey(request));
+  if (cachedAudio != null) {
+    playObjectUrl(cachedAudio.objectUrl, playbackToken);
     return;
   }
 
@@ -304,28 +332,7 @@ export function initializeSpeech() {
   }
 
   hasInitialized = true;
-
-  const url = new URL(window.location.href);
-  const apiKey = url.searchParams.get(ELEVENLABS_API_KEY_PARAM)?.trim();
-  const voiceId = url.searchParams.get(ELEVENLABS_VOICE_ID_PARAM)?.trim();
-  const removedApiKey = url.searchParams.has(ELEVENLABS_API_KEY_PARAM);
-  const removedVoiceId = url.searchParams.has(ELEVENLABS_VOICE_ID_PARAM);
-  url.searchParams.delete(ELEVENLABS_API_KEY_PARAM);
-  url.searchParams.delete(ELEVENLABS_VOICE_ID_PARAM);
-  const hadHiddenParam = removedApiKey || removedVoiceId;
-
-  elevenLabsApiKey = apiKey || null;
-  configuredVoiceId = voiceId || null;
-  isElevenLabsDisabled = false;
-  speechStatus = {
-    isElevenLabsActive: false,
-  };
-
-  if (hadHiddenParam) {
-    window.history.replaceState(window.history.state, '', getUrlWithoutHiddenParams(url));
-  }
-
-  emitStatusChange();
+  setApiKeyState(readStoredApiKey());
 }
 
 export function speak(text: string, language: Language) {
@@ -347,6 +354,35 @@ export function useSpeechStatus() {
   return useSyncExternalStore(subscribeToSpeechStatus, getSpeechStatus, getSpeechStatus);
 }
 
+export function setElevenLabsApiKey(apiKey: string) {
+  const nextApiKey = apiKey.trim();
+  if (!nextApiKey || typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    window.localStorage.setItem(ELEVENLABS_API_KEY_STORAGE_KEY, nextApiKey);
+    setApiKeyState(nextApiKey);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function clearElevenLabsApiKey() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    window.localStorage.removeItem(ELEVENLABS_API_KEY_STORAGE_KEY);
+    setApiKeyState(null);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function resetSpeechServiceForTests() {
   currentAudio?.pause?.();
   currentAudio = null;
@@ -355,17 +391,13 @@ export function resetSpeechServiceForTests() {
   nextPlaybackToken = 0;
   hasInitialized = false;
   elevenLabsApiKey = null;
-  configuredVoiceId = null;
   isElevenLabsDisabled = false;
   speechStatus = {
+    hasElevenLabsApiKey: false,
+    hasElevenLabsError: false,
     isElevenLabsActive: false,
   };
-
-  for (const entry of speechCache.values()) {
-    URL.revokeObjectURL?.(entry.objectUrl);
-  }
-
-  speechCache.clear();
+  clearSpeechCache();
   window.speechSynthesis?.cancel?.();
   emitStatusChange();
 }

--- a/src/utils/word-sets.ts
+++ b/src/utils/word-sets.ts
@@ -16,6 +16,7 @@ let wordSetConfigsPromise: Promise<WordSetConfig[]> | null = null;
 const wordSetWordsCache = new Map<string, Promise<string[]>>();
 
 export const WORD_SET_SAMPLE_SIZES = [5, 10, 25, 50, 100] as const;
+export type WordSetSampleSize = (typeof WORD_SET_SAMPLE_SIZES)[number];
 
 export function resetWordSetCache() {
   wordSetConfigsPromise = null;


### PR DESCRIPTION
## What does this PR do?

Persists quiz setup choices and ElevenLabs TTS configuration in local storage so returning users can resume with their last-selected options and manage TTS directly in the app.

## Relevant implementation details

- Moves setup preferences into a persisted Zustand `setup` slice, sanitizes restored values, and reads language, exercise mode, input source, manual text, sample size, and selected word set from that shared state.
- Adds a `TTS` settings dialog in `AppShell` for saving and removing the ElevenLabs API key from local storage on the current device, without exposing the stored value back in the UI.
- Updates the speech service to initialize from local storage, report configured and error states to the UI, clear cached audio when the key changes, and fall back to browser speech with a toast after auth or quota failures.
- Keeps word-set restoration stable by preserving sample size and selected set across source switches and by falling back to manual mode when a saved word-set option is no longer available.
- Expands tests around persisted setup restoration, TTS key management, and ElevenLabs failure handling.

## How did you test this?

`bun run validate`
